### PR TITLE
Corrigiendo Incorrect use of ParentData widget

### DIFF
--- a/lib/presentation/widgets/custom_checkbox.dart
+++ b/lib/presentation/widgets/custom_checkbox.dart
@@ -17,21 +17,19 @@ class CustomCheckBox extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Expanded(
-      child: Row(
-        children: [
-          Checkbox(
-            value: value,
-            onChanged: isDataSaved // Si los datos están guardados, no permite cambiar el valor
-                ? null // Si está guardado, no se puede interactuar
-                : (bool? newValue) {
-              onChanged(newValue ?? false);
-            },
-            activeColor: AppColors.green, 
-          ),
-          Text(label),
-        ],
-      ),
+    return Row(
+      children: [
+        Checkbox(
+          value: value,
+          onChanged: isDataSaved
+              ? null // Si está guardado, no se puede interactuar
+              : (bool? newValue) {
+                  onChanged(newValue ?? false);
+                },
+          activeColor: AppColors.green,
+        ),
+        Text(label),
+      ],
     );
   }
 }


### PR DESCRIPTION
Corrigiendo excepción "Incorrect use of ParentData widget", generada en la pantalla de pruebas maternal_step3. Se elimina Expanded del CustomCheckBox. 